### PR TITLE
「留め」から「ピン留め」を除外する

### DIFF
--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -631,8 +631,14 @@ rules:
     expected: どこ
   - pattern: 途端
     expected: とたん
-  - pattern: /(<!ピン)留([まめ])/
-    expected: とど$1
+  - pattern: /(ピン)?留([まめ])/
+    regexpMustEmpty: $1
+    expected: とど$2
+    specs:
+      - from: ピン留め
+        to:   ピン留め
+      - from: 踏み留まる
+        to:   踏みとどまる
   - pattern: /とは言え([^なまる])/
     expected: とはいえ$1
   - pattern: 共に

--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -631,7 +631,7 @@ rules:
     expected: どこ
   - pattern: 途端
     expected: とたん
-  - pattern: /留([まめ])/
+  - pattern: /(<!ピン)留([まめ])/
     expected: とど$1
   - pattern: /とは言え([^なまる])/
     expected: とはいえ$1


### PR DESCRIPTION
ブラウザやアプリのウィンドウを固定する「ピン留め」機能が、「ピンとどめ」に修正されてしまうので除外してほしいです。

https://support.mozilla.org/ja/kb/pinned-tabs-keep-favorite-websites-open
https://msdn.microsoft.com/ja-jp/library/gg618532(v=vs.85).aspx