### PR TITLE
「たしかに」の無限ループを修正

### DIFF
--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -1167,7 +1167,7 @@ rules:
     expected: 疎結合
   - pattern: 確かに
     expected: たしかに
-  - pattern: たしか
+  - pattern: /たしか([^に])/
     expected: 確か
   - pattern: /確め([たなまれる])/
     expected: 確かめ$1


### PR DESCRIPTION
「確かに」→「たしかに」のエラーを修正すると「たしか」→「確か」
「たしか」→「確か」のエラーを修正すると「確かに」→「たしかに」
「確かに」→「たしかに」のエラーを修正すると「たしか」→「確か」
…と無限ループになってしまっているので修正。