### PR TITLE
「ベンダー」のエラーが消えないのを修正

### DIFF
--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -2053,7 +2053,7 @@ rules:
   - expected: ペアプログラミング$1
     pattern:  /ペアプロ([^グ])/
   - expected: ベンダー
-    pattern:  /ベンダ/
+    pattern:  /ベンダ([^ー])/
   - expected: ヘッダ
     pattern:  /ヘッダー|ヘッタ|ヘッター/
   - expected: ベクタ


### PR DESCRIPTION
「ベンダ」を「ベンダー」に修正しても、「ベンダ（ー）」の部分だけを見てエラーが出続けるのを修正。