### PR TITLE
allow `WEB+DB PRESS`

### DIFF
--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -1666,8 +1666,6 @@ rules:
   - expected: $1Web$2
     pattern:  /(?:([^/])ウェブ)|(?:ウェブ([^/\+]))/
   - expected: $1Web$2
-    pattern:  /(?:([^/])\bWEB)|(?:WEB\b([^/\+]))/
-  - expected: $1Web$2
     pattern:  /(?:([^/])ウェッブ)|(?:ウェッブ([^/\+]))/
   - expected: O/Rマッ
     pattern:  /ORマッ|O-Rマッ/
@@ -3020,3 +3018,5 @@ rules:
     pattern:  /([^も])のの/
   - expected: は
     pattern:  /はは/
+  - expected: "WEB+DB PRESS"
+    pattern:  /WEB\+DB PRESS/i


### PR DESCRIPTION
`WEB+DB PRESS`がWEB+DB_PRESS.ymlルールで通らないのは切ないというかマズイので修正するものです。

```
  - expected: Web
```

という行もあるので、ふつうに「web」とかの表記は「Web」になりそうですが、

```
  - expected: $1Web$2
    pattern:  /(?:([^/])\bWEB)|(?:WEB\b([^/\+]))/
```

がないと駄目なんでしたっけ…？