### PR TITLE
WEB+DB_PRESS.ymlのルールを改善

### DIFF
--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -1335,8 +1335,13 @@ rules:
     expected: 内蔵
   - pattern: /なか([かでに])/
     expected: 中$1
-  - pattern: /なら([ばびぶべぼん])/
+  - pattern: /なら(ば(?!、)|[びぶべぼん])/
     expected: 並$1
+    specs:
+      - from: ならびに
+        to:   並びに
+      - from: ならば、
+        to:   ならば、
   - pattern: /著わ([さしすせそ])/
     expected: 著$1
   - pattern: 著い

--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -653,7 +653,7 @@ rules:
       - 取り敢えず
     expected: とりあえず
   - pattern: /([^有])無([かくいけし])/
-    expected: $1な$1
+    expected: $1な$2
   - pattern: /尚([^早徳])/
     expected: なお$1
   - pattern:

--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -587,11 +587,17 @@ rules:
     expected: づら$1
   - pattern: んで([たなるろよ])
     expected: んでい$1
-  - pattern: /てな(?!く)/
-    expected: ていな
+  - pattern: /ってな(?!く)/
+    expected: っていな
     specs:
       - from: わかってない
         to:   わかっていない
+      - from: 言ってない
+        to:   言っていない
+      - from: 走ってない
+        to:   走っていない
+      - from: 持てない
+        to:   持てない
       - from: 消えてなくなる
         to:   消えてなくなる
   - pattern: /([^捨当立])てる/


### PR DESCRIPTION
- `無` => `な` の expectedを修正
- `てな` の誤検出を修正
   - `ってな` を検出するルールに変更
   - テストケースを追加
- `なら` => `並` への変換で `ならば、` が誤検出される問題を修正