### PR TITLE
ででの検出で「までです」が引っかかる問題を修正

### DIFF
--- a/languages/ja/typo.yml
+++ b/languages/ja/typo.yml
@@ -10,11 +10,13 @@ rules:
   - expected: なるほど
     pattern:  なほるど
   - expected: で
-    pattern:  /でで(?!きる)/
+    pattern:  /(^ま)?でで(?!(きる|きます|す))/
     specs:
       - from: でで
         to:   で
       - from: Aでできる
         to:   Aでできる
+      - from: までです
+        to: までです
   - expected: を
     pattern:  をを

--- a/languages/ja/typo.yml
+++ b/languages/ja/typo.yml
@@ -10,7 +10,7 @@ rules:
   - expected: なるほど
     pattern:  なほるど
   - expected: で
-    pattern:  /(^ま)?でで(?!(きる|きます|す))/
+    pattern:  /(?<!ま)でで(?!(きる|きます|す))/
     specs:
       - from: でで
         to:   で


### PR DESCRIPTION
以前のルールでは「締切は明日までです」のような文がルールに引っかかっていました。
これを修正しました。

テストケースが用意できればよかったのですが、ルールのテストはなかったようなので作成はしていません。
手元で動作確認を行っています。

更新によりエラー検出されなくなる文章例:

- 明日までです
- Bまでできます
- Aでできます

など。