### PR TITLE
「おこなう」を「行う」に置換する際に送り仮名が失われないようにする

### DIFF
--- a/media/WEB+DB_PRESS.yml
+++ b/media/WEB+DB_PRESS.yml
@@ -1221,7 +1221,7 @@ rules:
     expected: 語ら$1
   - pattern: /交([らりるれろっ])/
     expected: 交わ$1
-  - pattern: /行な([わいうえおっ])|おこな([わいうえおっ])/
+  - pattern: /(?:行|おこ)な([わいうえおっ])/
     expected: 行$1
   - pattern: あわて
     expected: 慌


### PR DESCRIPTION
キャプチャ部が使われているのに適切にそのキャプチャがおこなわれていないがために自動置換によって送り仮名が失われているのを修正．

ぱっと見，以下の範囲など他にも同様の問題のある箇所が大量にありそうですが……

https://github.com/prh/rules/blob/711e00793d9d69eeda04d68a796b6d9afb6d5748/media/WEB%2BDB_PRESS.yml#L834-L875