### PR TITLE
依存関係の更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,145 +1,69 @@
 {
   "name": "prh-rules",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "balanced-match": {
+  "packages": {
+    "": {
+      "name": "prh-rules",
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+      "license": "MIT",
+      "dependencies": {
+        "prh": "^6.0.1"
       }
     },
-    "commandpost": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
-      "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ=="
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "glob": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-      "dev": true,
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^2.0.1",
-        "once": "^1.3.0"
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
-    "glob-expand": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/glob-expand/-/glob-expand-0.2.1.tgz",
-      "integrity": "sha1-GwiKwnK1cViHC3aBYRHaRhimag8=",
-      "dev": true,
-      "requires": {
-        "glob": "~4.5.x",
-        "lodash": "~4.13.x"
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+    "node_modules/prh": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prh/-/prh-6.0.1.tgz",
+      "integrity": "sha512-lO9OStsj3IF+7c6ig+mcP6vCeUgOrLEkRg+DJukcrALnBNCitBO/7r/toJBFY8DF3x1cELKEy8HRCGvduSTQDA==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "diff": "^8.0.3",
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "prh": "bin/prh"
+      },
+      "engines": {
+        "node": ">=22"
       }
-    },
-    "lodash": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-      "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.0.0"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "prh": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.3.tgz",
-      "integrity": "sha512-W5+gzqOrVLKayPh+2QCur7KYZPsLRfDJd4Tyz5lIXAWwqaX/LQ40FX/P3/Hbfgf7w+EQPdR1yOx6BVf+frG40w==",
-      "requires": {
-        "commandpost": "^1.2.1",
-        "diff": "^3.3.0",
-        "js-yaml": "^3.9.1"
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   },
   "homepage": "https://github.com/prh/rules#readme",
   "dependencies": {
-    "prh": "^5.4.3"
-  },
-  "devDependencies": {
-    "glob-expand": "^0.2.1"
+    "prh": "^6.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,22 +1,22 @@
 "use strict";
 
-const expand = require("glob-expand");
+const fs = require("fs");
 const prh = require("prh");
 const assert = require("assert");
 
-const ymlList = expand({ filter: "isFile", cwd: __dirname }, [
-    "**/*.yml",
-    "!node_modules/**",
-]);
+const ymlList = fs.globSync("**/*.yml", {
+  cwd: __dirname,
+  exclude: (p) => p === "node_modules",
+});
 
-ymlList.forEach(yml => {
-    try {
-        const engine = prh.fromYAMLFilePath(yml);
-        const changeSet = engine.makeChangeSet("./README.ja.md");
-    } catch (e) {
-        console.log(`processing... ${yml}\n`);
-        throw e;
-    }
+ymlList.forEach((yml) => {
+  try {
+    const engine = prh.fromYAMLFilePath(yml);
+    const changeSet = engine.makeChangeSet("./README.ja.md");
+  } catch (e) {
+    console.log(`processing... ${yml}\n`);
+    throw e;
+  }
 });
 
 console.log("😸 done");


### PR DESCRIPTION
## Summary
- prh を 5.4.3 から 6.0.1 にメジャーアップデート
- glob-expand を削除し、Node.js 標準の `fs.globSync` に置き換え（devDependencies ゼロに）
- 脆弱性のある依存関係（lodash, minimatch, glob 等）を一掃し、`npm audit` の脆弱性を 5件 → 0件 に

## Test plan
- [x] `npm test` がパスすることを確認済み
- [x] `npm audit` で脆弱性が 0 件であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)