### PR TITLE
GitHub Actions CI、Dependabot、CODEOWNERS を追加

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vvakame

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: "package.json"
+          cache: "npm"
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/prh/rules/issues"
   },
   "homepage": "https://github.com/prh/rules#readme",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "prh": "^6.0.1"
   }


### PR DESCRIPTION
## Summary
- prh 本体の構成に合わせて GitHub Actions CI ワークフローを追加（push/PR on master で `npm test` 実行）
- Dependabot 設定を追加（npm + github-actions を weekly チェック）
- CODEOWNERS を追加（`* @vvakame`）
- `package.json` に `engines` フィールドを追加（`node >= 22`、`setup-node` の `node-version-file` 用）

## Test plan
- [x] CI ワークフローが PR 上で正常に実行されることを確認
- [x] `npm test` が CI 上で pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)